### PR TITLE
Added null check to fix build error

### DIFF
--- a/src/components/header.js
+++ b/src/components/header.js
@@ -1,5 +1,5 @@
 import { Link, useStaticQuery, graphql } from 'gatsby';
-import React, { useState  } from 'react';
+import React, { useState } from 'react';
 import BlueFCCLogo from '../assets/FCC-Nashville-blue-logo.svg';
 import OrangeFCCLogo from '../assets/FCC-Nashville-orange-logo.svg';
 
@@ -15,17 +15,25 @@ function Header() {
     }
   `);
 
-  const logo = (path) => {
-    if (path !== '/') return < OrangeFCCLogo className="logo" alt={`${site.siteMetadata.title} Logo`} />
-    return < BlueFCCLogo className="logo" alt={`${site.siteMetadata.title} Logo`} />
-  }     
+  const currentPathname =
+    typeof window !== `undefined` ? window.location.pathname : '/';
+  const logo = path => {
+    if (path !== '/')
+      return (
+        <OrangeFCCLogo
+          className="logo"
+          alt={`${site.siteMetadata.title} Logo`}
+        />
+      );
+    return (
+      <BlueFCCLogo className="logo" alt={`${site.siteMetadata.title} Logo`} />
+    );
+  };
 
   return (
     <header className="bg-white">
       <div className="navBar">
-        <Link to="/">
-            {logo(location.pathname)}
-        </Link>
+        <Link to="/">{logo(currentPathname)}</Link>
 
         <button
           className="navMenuButton"
@@ -41,11 +49,7 @@ function Header() {
           </svg>
         </button>
 
-        <nav
-          className={`${
-            isExpanded ? `block` : `hidden`
-          } navMenu`}
-        >
+        <nav className={`${isExpanded ? `block` : `hidden`} navMenu`}>
           {[
             {
               route: `/`,
@@ -60,11 +64,7 @@ function Header() {
               title: `Code Of Conduct`,
             },
           ].map(link => (
-            <Link
-              className="navMenuItems"
-              key={link.title}
-              to={link.route}
-            >
+            <Link className="navMenuItems" key={link.title} to={link.route}>
               {link.title}
             </Link>
           ))}


### PR DESCRIPTION
Added null check to `location` property to fix a build error that was introduced in PR #47. The site was working fine in development mode with the `gatsby develop` command, but broke with `gatsby build`. I resolved the issue using the recommended fix listed here as number 1: https://www.gatsbyjs.com/docs/debugging-html-builds/

I assumed that `location` in the original PR is the same as `window.location`, but I'm not entirely sure if those are the same or different than `document.location`.  [The article on MDN for location](https://developer.mozilla.org/en-US/docs/Web/API/Location) links to the same W3 spec that [the article for window.location](https://developer.mozilla.org/en-US/docs/Web/API/Window/location) does, so I assumed it is.

Main changes are the introduction of lines 18 and 19, and change to the function invocation on line 36. The rest of the changes were introduced by my linter.