### PR TITLE
Fix the CSS over writes that was causing the logo color to change

### DIFF
--- a/src/components/header.js
+++ b/src/components/header.js
@@ -21,12 +21,15 @@ function Header() {
     if (path !== '/')
       return (
         <OrangeFCCLogo
-          className="logo"
-          alt={`${site.siteMetadata.title} Logo`}
+          className="logo logoOrange"
+          alt={`${site.siteMetadata.title} Orange Logo`}
         />
       );
     return (
-      <BlueFCCLogo className="logo" alt={`${site.siteMetadata.title} Logo`} />
+      <BlueFCCLogo
+        className="logo logoBlue"
+        alt={`${site.siteMetadata.title} Blue Logo`}
+      />
     );
   };
 

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -57,9 +57,22 @@
   @apply absolute w-32 h-20 ml-16 mt-8 left-0 top-0;
 }
 
+.logoOrange .cls-1 {
+  @apply fill-current text-FCCorange;
+}
+
+.logoBlue .cls-1 {
+  @apply fill-current text-FCCblue-200;
+}
+
 .logo .cls-2 {
-  font-weight: 400 !important;
+  @apply font-normal fill-current text-white font-Pacifico;
   transform: translate(65px, 180px);
+  font-size: 60px;
+}
+
+.logo .cls-3 {
+  @apply stroke-current text-black  bg-opacity-0;
 }
 
 .connectLogo .cls-1,


### PR DESCRIPTION
PR for the HOTFIX: The main logo is now Orange rather than Blue and needs to Fixed. For information see this ticket #73

- Updated the style.css with more specific CSS classes to target both the orange logo, blue logo, and both logo's share CSS attributes
- Add a new class for each logo in the header.js for the CSS to target