### PR TITLE
Mobile navbar

### DIFF
--- a/src/components/header.js
+++ b/src/components/header.js
@@ -1,7 +1,7 @@
 import { Link, useStaticQuery, graphql } from 'gatsby';
 import React, { useState } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faBars } from '@fortawesome/free-solid-svg-icons';
+import { faBars, faTimes } from '@fortawesome/free-solid-svg-icons';
 import BlueFCCLogo from '../assets/FCC-Nashville-blue-logo.svg';
 import OrangeFCCLogo from '../assets/FCC-Nashville-orange-logo.svg';
 import componentStyles from './header.module.css';
@@ -57,13 +57,22 @@ function Header() {
         <Link to="/">{logo(currentPathname)}</Link>
 
         <button
-          className={componentStyles.navMenuButton}
+          className={`${componentStyles.navMenuButton} relative`}
           onClick={() => toggleExpansion(!isExpanded)}
         >
           <FontAwesomeIcon
+            icon={faTimes}
+            size="2x"
+            className={`${componentStyles.timesIcon} ${
+              isExpanded ? `${componentStyles.isExpanded}` : ``
+            } fill-current text-white`}
+          />
+          <FontAwesomeIcon
             icon={faBars}
             size="2x"
-            color={isExpanded ? `white` : `black`}
+            className={`${componentStyles.barsIcon} ${
+              isExpanded ? `${componentStyles.isExpanded}` : ``
+            } fill-current text-gray-700`}
           />
         </button>
 

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -1,5 +1,7 @@
 import { Link, useStaticQuery, graphql } from 'gatsby';
 import React, { useState } from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faBars } from '@fortawesome/free-solid-svg-icons';
 import BlueFCCLogo from '../assets/FCC-Nashville-blue-logo.svg';
 import OrangeFCCLogo from '../assets/FCC-Nashville-orange-logo.svg';
 import componentStyles from './header.module.css';
@@ -58,14 +60,11 @@ function Header() {
           className={componentStyles.navMenuButton}
           onClick={() => toggleExpansion(!isExpanded)}
         >
-          <svg
-            className={componentStyles.burgerIcon}
-            viewBox="0 0 20 20"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <title>Menu</title>
-            <path d="M0 3h20v2H0V3zm0 6h20v2H0V9zm0 6h20v2H0v-2z" />
-          </svg>
+          <FontAwesomeIcon
+            icon={faBars}
+            size="2x"
+            color={isExpanded ? `white` : `black`}
+          />
         </button>
 
         <MobileNavbar navbarLinks={navbarLinks} isExpanded={isExpanded} />

--- a/src/components/header.js
+++ b/src/components/header.js
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import BlueFCCLogo from '../assets/FCC-Nashville-blue-logo.svg';
 import OrangeFCCLogo from '../assets/FCC-Nashville-orange-logo.svg';
 import componentStyles from './header.module.css';
+import MobileNavbar from './mobile-navbar';
 
 function Header() {
   const [isExpanded, toggleExpansion] = useState(false);
@@ -16,6 +17,20 @@ function Header() {
     }
   `);
 
+  const navbarLinks = [
+    {
+      route: `/`,
+      title: `Home`,
+    },
+    {
+      route: `/about`,
+      title: `About`,
+    },
+    {
+      route: `/code-of-conduct`,
+      title: `Code Of Conduct`,
+    },
+  ];
   const currentPathname =
     typeof window !== `undefined` ? window.location.pathname : '/';
   const logo = path => {
@@ -53,25 +68,10 @@ function Header() {
           </svg>
         </button>
 
-        <nav
-          className={
-            `${isExpanded ? `block` : `hidden`} ` + componentStyles.navMenu
-          }
-        >
-          {[
-            {
-              route: `/`,
-              title: `Home`,
-            },
-            {
-              route: `/about`,
-              title: `About`,
-            },
-            {
-              route: `/code-of-conduct`,
-              title: `Code Of Conduct`,
-            },
-          ].map(link => (
+        <MobileNavbar navbarLinks={navbarLinks} isExpanded={isExpanded} />
+
+        <nav className={componentStyles.navMenu}>
+          {navbarLinks.map(link => (
             <Link
               className={componentStyles.navMenuItems}
               key={link.title}

--- a/src/components/header.module.css
+++ b/src/components/header.module.css
@@ -24,12 +24,17 @@
   @apply flex flex-wrap items-center justify-between max-w-5xl mx-auto;
 }
 
-.burgerIcon {
-  @apply w-10 h-6 mr-16 mt-16 fill-current;
+.navMenu {
+  @apply hidden;
 }
 
-.navMenu {
-  @apply w-full;
+.navMenuButton {
+  z-index: 1000;
+  @apply mr-12 mt-12;
+}
+
+.burgerIcon {
+  @apply w-10 h-6 m-2 fill-current;
 }
 
 .navMenuItems {

--- a/src/components/header.module.css
+++ b/src/components/header.module.css
@@ -33,10 +33,6 @@
   @apply mr-12 mt-12;
 }
 
-.burgerIcon {
-  @apply w-10 h-6 m-2 fill-current;
-}
-
 .navMenuItems {
   @apply block mt-4 font-medium text-FCCgray-200 no-underline font-Roboto text-xl uppercase;
 }

--- a/src/components/header.module.css
+++ b/src/components/header.module.css
@@ -33,6 +33,36 @@
   @apply mr-12 mt-12;
 }
 
+.navMenuButton .barsIcon {
+  position: relative;
+  top: 0;
+  left: 0;
+  visibility: visible;
+  opacity: 1;
+  transition: visibility 0.25s, opacity 0.25s, left 0.5s;
+}
+
+.navMenuButton .barsIcon.isExpanded {
+  left: -100%;
+  visibility: hidden;
+  opacity: 0;
+}
+
+.navMenuButton .timesIcon {
+  position: absolute;
+  top: 0;
+  left: 120%;
+  visibility: hidden;
+  opacity: 0;
+  transition: visibility 0.25s, opacity 0.25s, left 0.5s;
+}
+
+.navMenuButton .timesIcon.isExpanded {
+  left: 20%;
+  visibility: visible;
+  opacity: 1;
+}
+
 .navMenuItems {
   @apply block mt-4 font-medium text-FCCgray-200 no-underline font-Roboto text-xl uppercase;
 }

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -6,7 +6,7 @@ import Footer from './footer';
 
 function Layout({ children }) {
   return (
-    <div className="flex flex-col min-h-screen font-sans text-gray-900">
+    <div className="relative flex flex-col min-h-screen w-full overflow-x-hidden font-sans text-gray-900">
       <Header />
 
       <main className="flex-1">{children}</main>

--- a/src/components/mobile-navbar.js
+++ b/src/components/mobile-navbar.js
@@ -8,7 +8,7 @@ function MobileNavbar({ navbarLinks, isExpanded }) {
     <div
       className={`${componentStyles.navbarMenu} ${
         isExpanded ? `${componentStyles.isExpanded}` : ``
-      } bg-FCCblue-200 w-3/4 h-full pt-24`}
+      } bg-FCCblue-200 w-3/4 pt-24`}
     >
       {navbarLinks.map(link => (
         <Link

--- a/src/components/mobile-navbar.js
+++ b/src/components/mobile-navbar.js
@@ -7,8 +7,8 @@ function MobileNavbar({ navbarLinks, isExpanded }) {
   return (
     <div
       className={`${componentStyles.navbarMenu} ${
-        isExpanded ? `block` : `hidden`
-      } bg-FCCblue-200 w-3/4 h-full absolute top-0 right-0 pt-24`}
+        isExpanded ? `${componentStyles.isExpanded}` : ``
+      } bg-FCCblue-200 w-3/4 h-full pt-24`}
     >
       {navbarLinks.map(link => (
         <Link

--- a/src/components/mobile-navbar.js
+++ b/src/components/mobile-navbar.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Link } from 'gatsby';
+import componentStyles from './mobile-navbar.module.css';
+
+function MobileNavbar({ navbarLinks, isExpanded }) {
+  return (
+    <div
+      className={`${componentStyles.navbarMenu} ${
+        isExpanded ? `block` : `hidden`
+      } bg-FCCblue-200 w-3/4 h-full absolute top-0 right-0 pt-24`}
+    >
+      {navbarLinks.map(link => (
+        <Link
+          className="block mt-12 mr-12 text-right font-Roboto uppercase text-white text-xl font-bold"
+          key={link.title}
+          to={link.route}
+        >
+          {link.title}
+        </Link>
+      ))}
+    </div>
+  );
+}
+
+MobileNavbar.defaultProps = {
+  navbarLinks: [],
+  isExpanded: false,
+};
+
+MobileNavbar.propTypes = {
+  navbarLinks: PropTypes.arrayOf(PropTypes.object),
+  isExpanded: PropTypes.bool,
+};
+
+export default MobileNavbar;

--- a/src/components/mobile-navbar.module.css
+++ b/src/components/mobile-navbar.module.css
@@ -2,6 +2,7 @@
   position: absolute;
   top: 0;
   left: 100%;
+  height: 100vh;
   margin-left: 25%;
   border-top-left-radius: 30px;
   border-bottom-left-radius: 30px;

--- a/src/components/mobile-navbar.module.css
+++ b/src/components/mobile-navbar.module.css
@@ -1,17 +1,24 @@
 .navbarMenu {
+  position: absolute;
+  top: 0;
+  left: 100%;
+  margin-left: 25%;
   border-top-left-radius: 30px;
   border-bottom-left-radius: 30px;
   box-shadow: -5px 5px 6px 3px rgb(0 0 0 / 25%);
+  visibility: hidden;
+  opacity: 0;
+  transition: visibility 0.25s, opacity 0.25s, left 0.5s;
+}
+
+.navbarMenu.isExpanded {
+  left: 0;
+  visibility: visible;
+  opacity: 1;
 }
 
 @screen md {
   .navbarMenu {
-    @apply hidden;
+    display: none;
   }
 }
-/* 
-a {
-  display: block;
-  text-align: right;
-  margin-right: 50px;
-} */

--- a/src/components/mobile-navbar.module.css
+++ b/src/components/mobile-navbar.module.css
@@ -1,0 +1,17 @@
+.navbarMenu {
+  border-top-left-radius: 30px;
+  border-bottom-left-radius: 30px;
+  box-shadow: -5px 5px 6px 3px rgb(0 0 0 / 25%);
+}
+
+@screen md {
+  .navbarMenu {
+    @apply hidden;
+  }
+}
+/* 
+a {
+  display: block;
+  text-align: right;
+  margin-right: 50px;
+} */


### PR DESCRIPTION
Resolves #48

# Description of Changes
Adds a navbar to the mobile version of our site, fitting our design mockup: https://xd.adobe.com/view/3640d8e0-d80d-43e5-b7d0-fe240a00644f-6313/. The sliding transition animation is something I added, but should behave properly. The navbar is rendered `display: none;` when in desktop resolutions.

One thing to note: The hamburger and 'X' icons use the Font Awesome designs and don't match the icons in the mockup. Is this a big issue? I wasn't sure how to export the SVGs from the mockup.

## How Can I Test This?
Open up the test branch on Netlify and test the buttons in mobile resolutions (in Chrome, pull open the devtools with Ctrl+Shift+I and activate the device toolbar with Ctrl+Shift+M, then choose either "Responsive" resolution at the top or any mobile device on the list).