### PR TITLE
Added z-index:1 to mobile-navbar.module.css

### DIFF
--- a/src/components/mobile-navbar.module.css
+++ b/src/components/mobile-navbar.module.css
@@ -16,6 +16,7 @@
   left: 0;
   visibility: visible;
   opacity: 1;
+  z-index: 1;
 }
 
 @screen md {


### PR DESCRIPTION
This PR is for issue #92 
I added `z-index: 1;` to the `.navbarMenu.isExpanded` selector

The navbar on mobile is no longer covered by the connect SVG logo

![image](https://user-images.githubusercontent.com/43410858/135732605-69da78e4-b445-4675-a6b8-8c5b896afaa8.png)
---
Please let me know if I need to make any changes
